### PR TITLE
Change kubectl-neat dependency repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ De-clutter your `kubectl diff` output using [kubectl-neat](https://github.com/it
 You can try `go get`:
 
 ```bash
-$ GO111MODULE=on go get github.com/sh0rez/kubectl-neat-diff
+$ GO111MODULE=on go get github.com/zzehring/kubectl-neat-diff
 ```
 
 If that doesn't work, clone and build manually:
 
 ```bash
-$ git clone https://github.com/sh0rez/kubectl-neat-diff
+$ git clone https://github.com/zzehring/kubectl-neat-diff
 $ cd kubectl-neat-diff
 $ make install
 ```

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/go-clix/cli v0.2.0
-	github.com/itaysk/kubectl-neat v1.2.0
+	github.com/itaysk/kubectl-neat v2.0.3
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sh0rez/kubectl-neat-diff
+module github.com/zzehring/kubectl-neat-diff
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -7,28 +7,3 @@ require (
 	github.com/itaysk/kubectl-neat v1.2.0
 	sigs.k8s.io/yaml v1.1.0
 )
-
-replace (
-	k8s.io/api => k8s.io/api v0.17.0
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.0
-	k8s.io/apimachinery => k8s.io/apimachinery v0.17.0
-	k8s.io/apiserver => k8s.io/apiserver v0.17.0
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.17.0
-	k8s.io/client-go => k8s.io/client-go v0.17.0
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.17.0
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.17.0
-	k8s.io/code-generator => k8s.io/code-generator v0.17.0
-	k8s.io/component-base => k8s.io/component-base v0.17.0
-	k8s.io/cri-api => k8s.io/cri-api v0.17.0
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.17.0
-	k8s.io/kubctl => k8s.io/kubctl v0.17.0
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.17.0
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.17.0
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.17.0
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.17.0
-	k8s.io/kubectl => k8s.io/kubectl v0.17.0
-	k8s.io/kubelet => k8s.io/kubelet v0.17.0
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.17.0
-	k8s.io/metrics => k8s.io/metrics v0.17.0
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.0
-)

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,7 @@ go 1.15
 
 require (
 	github.com/go-clix/cli v0.2.0
-	github.com/itaysk/kubectl-neat v1.2.0
-	sigs.k8s.io/yaml v1.1.0
+	github.com/zzehring/kubectl-neat/v2 v2.0.6
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -83,7 +83,6 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -481,6 +480,8 @@ github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59b
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/zzehring/kubectl-neat/v2 v2.0.6 h1:2kvBKl7D5qFbEqynVD3J/J3T1HwCs+thcl8ey0r58rc=
+github.com/zzehring/kubectl-neat/v2 v2.0.6/go.mod h1:VFoKfs1klOUbJ/leyd/qaEPfoz54XrL4Fp4hBoHFJ4c=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
@@ -631,7 +632,6 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -650,7 +650,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/warnings.v0 v0.1.1/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
@@ -713,7 +712,6 @@ mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIa
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34/go.mod h1:H6SUd1XjIs+qQCyskXg5OFSrilMRUkD8ePJpHKDPaeY=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/go-clix/cli"
-	neat "github.com/itaysk/kubectl-neat/cmd"
+	neat "github.com/zzehring/kubectl-neat/v2/cmd"
 )
 
 func main() {
@@ -52,7 +52,7 @@ func neatifyDir(dir string) error {
 			return err
 		}
 
-		n, err := neat.NeatYAMLOrJSON(data)
+		n, err := neat.NeatYAMLOrJSON(data, "same")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The original kubectl-neat repo currently has a go mod conflict between
the latest tag (v2.0.3) and the modpath (which has not added v2
suffix). This will hopefully allow for a smooth 'go get' experience.